### PR TITLE
Increase req version of scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
 # Already in Colab
 jupyter~=1.0.0
 jupytext~=1.11.3
-scipy~=1.4.1
+scipy~=1.6.0
 
 # On newer MacOS, need mpl>=3.3 coz of https://bugs.python.org/issue33725 .
 matplotlib~=3.3.4


### PR DESCRIPTION
My system:

Machine: Intel Macbook pro
OS: Big Sur
Python 3.9.4

Installing the required version of scipy, which is 1.4.1 throws the following error:

`numpy.distutils.system_info.NotFoundError: No lapack/blas resources found. Note: Accelerate is no longer supported.`

[Other people are having similar issues](https://github.com/scipy/scipy/issues/13102)

My proposed fix is to change the required version of scipy to `scipy~=1.6.0`.

I ran `MAIN.ipynb` after making this change without issues.

Thanks