### PR TITLE
Call fields with correct args in main

### DIFF
--- a/tools/geostat.py
+++ b/tools/geostat.py
@@ -3,6 +3,7 @@
 import numpy as np
 import scipy.linalg as sla
 from matplotlib import pyplot as plt
+
 from mpl_tools.place import freshfig
 from numpy.random import randn
 
@@ -86,4 +87,4 @@ if __name__ == "__main__":
     fields = gaussian_fields(grid.mesh(), N)
     fields = 0.5 + .2*fields
     # fields = truncate_01(fields)
-    plots.fields(plots.field, fields)
+    plots.fields(fields)

--- a/tools/geostat.py
+++ b/tools/geostat.py
@@ -3,7 +3,6 @@
 import numpy as np
 import scipy.linalg as sla
 from matplotlib import pyplot as plt
-
 from mpl_tools.place import freshfig
 from numpy.random import randn
 


### PR DESCRIPTION
`simulator.plotting.fields` is called with wrong arguments in main of `geostat.py` and throws the following error:

```console
Traceback (most recent call last):
  File "/Users/fedacuric/Dropbox/HistoryMatching/tools/geostat.py", line 90, in <module>
    plots.fields(plots.field, fields)
  File "/Users/fedacuric/Dropbox/HistoryMatching/simulator/plotting.py", line 156, in fields
    title = dash("Fields", kw("title"), title)
  File "/Users/fedacuric/Dropbox/HistoryMatching/simulator/plotting.py", line 153, in <lambda>
    kw = lambda k: pop_style_with_fallback(k, style, kwargs)
  File "/Users/fedacuric/Dropbox/HistoryMatching/simulator/plotting.py", line 73, in pop_style_with_fallback
    x = styles[style or "default"].get(key, x)
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Running `python -i tools/geostat.py` works after fix and produces two figures.
